### PR TITLE
Serve ".md" files; rewrite requests to directories lacking a slash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'rack-jekyll', :git => 'https://github.com/awood/rack-jekyll'
 gem 'nokogiri', "~> 1.5.2"
 gem 'stringex'
 gem 'rack'
+gem 'rack-rewrite'
 gem 'thin'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
     rack (1.5.2)
     rack-livereload (0.3.15)
       rack
+    rack-rewrite (1.5.1)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -132,6 +133,7 @@ DEPENDENCIES
   rack
   rack-jekyll!
   rack-livereload
+  rack-rewrite
   safe_yaml
   stringex
   thin

--- a/config.ru
+++ b/config.ru
@@ -1,9 +1,13 @@
 require 'rack/jekyll'
+require 'rack/rewrite'
 
-use Rack::Static,
-  # Poor man's redirects
-  :urls => {
-    "/favicon.ico" => "/images/favicon.ico"
-  }
+use Rack::Rewrite do
+  rewrite "/favicon.ico", "/images/favicon.ico"
+  # The (?!.*?\.|.+/$) is a negative lookahead making sure that the last part
+  # of the requested path does not have a period in it or end with a slash.
+  # If there is a period, then the user is requesting a file.  If there is a
+  # trailing slash, the user is requesting a directory.
+  moved_permanently %r{(/.*/)((?!.+?\.|.+/$).+)}, '$1$2/'
+end
 
-run Rack::Jekyll.new(:no_render => true)
+run Rack::Jekyll.new(:no_render => true, :additional_mime_types => ".md")


### PR DESCRIPTION
Requests to "/foo/bar" are now redirected to "/foo/bar/".  The
redirection is based on a regex that detects if the last portion of the
path contains a period or ends in a slash.  In either of those two
cases, no redirection occurs.