### PR TITLE
Update of introduction in Candlepin docs

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -24,20 +24,11 @@
   - section: getting_started
     subs:
       - section: overview
-        subs:
-          - section: glossary
-      - section: how_subscriptions_work
+      - section: products_and_subscriptions
         subs:
           - section: subscription_types
-          - section: subscription_management
-          - section: storage_band_subscriptions
-          - section: constraints
-      - section: entitlements
-        subs:
-          - section: autobind
-          - section: server_side_entitlement_status
-          - section: expired_entitlements
-          - section: revoke_entitlements
+          - section: pool_types
+          - section: product_attributes
       - section: virtualization_entitlements
         subs:
           - section: virt_guest_limit_design
@@ -92,6 +83,7 @@
           - section: hibernate
       - section: implementation_details
         subs:
+          - section: storage_band_subscriptions
           - section: revoke_entitlements_implementation 
       - section: debugging
         subs:
@@ -113,7 +105,12 @@
     subs:
       - section: api
       - section: database
-      - section: product_attributes
+      - section: entitlements
+        subs:
+          - section: autobind
+          - section: server_side_entitlement_status
+          - section: expired_entitlements
+          - section: revoke_entitlements
   - section: design
     subs:
       - section: compliance_snapshots
@@ -130,3 +127,7 @@
       - section: servlet_container
       - section: api_version_design
       - section: federated_certificate_management
+      - section: constraints
+      - section: subscription_management
+      - section: how_subscriptions_work
+      - section: glossary

--- a/docs/candlepin/glossary.md
+++ b/docs/candlepin/glossary.md
@@ -4,27 +4,25 @@ title: Glossary
 # Candlepin Terms
 It is helpful to understand the high level terms in the candlepin data model. A basic diagram of the model is:
 
-![]({{ site.baseurl }}/images/model.png){:.center-block}
 
-In that diagram you will see the following terms
 
 Owner
 : an organization who has purchased subscriptions to products.
 
-Subscription
-: The right to consume a given product.
+Marketing Product
+: A piece of software or service which can be used by the owner.
 
-Product
-: An item or service which can be subscribed to by the owner.
+Subscription
+: The right to consume a given Marketing Product.
+
+Subscription Pool
+: The right to consume a given Marketing Product. It is essentially a copy of Subscription with additional processing done by Candlepin. Candlepin chooses to operate with Subscription Pools instead of with Subscriptions directly.
 
 Consumer
 : An entity (person, system, etc) within the owner who may wish to make use of products.
 
 Entitlement
-: The right to use a product
-
-Entitlement Pool
-: The collection of entitlements which are available to be consumed based on a subscription
+: Consumption of a Subscription Pool by a Consumer.
 
 You will also see the other terms used throughout the wiki
 

--- a/docs/candlepin/overview.md
+++ b/docs/candlepin/overview.md
@@ -22,6 +22,36 @@ Candlepin has built in exention points for the concept of "Subscriptions",
 specific vendor need only integrate to these extension points and then they can
 take advantage of the core engine functionality.
 
+## Basic List of Candlepin Terms
+These are some high level descriptions of terms in the Candlepin data model. More detailed descriptions are in the next parts of the documentation
+
+Owner
+: an organization who has purchased subscriptions to products.
+
+Marketing Product
+: A piece of software or service which can be used by an owner.
+
+Subscription
+: The right to consume a given Marketing Product. Subscriptions must be imported into Candlepin, there are several methods to import, based on the deployment type of Candlepin.
+
+Subscription Pool
+: The right to consume a given Marketing Product. It is essentially a copy of Subscription with additional metadata added by Candlepin. Candlepin chooses to operate with Subscription Pools instead of with Subscriptions directly.
+
+Consumer
+: An entity (person, system, etc) within the owner who may wish to make use of the products.
+
+Entitlement
+: Consumption of a Subscription Pool by a Consumer. Entitlement is an abstract entity that is created when a Consumer uses (consumes) Subscription Pool.
+
+You will also see the other terms used throughout the wiki
+
+Entitlement Certificate
+: By default, an x.509 certficate which represents you right to consume a subscription. This certificate can be used to access software.
+
+Identity Certificate
+: By default, an x.509 certificate which unique identifies a single consumer.
+
+
 # Deployment
 In the simplest case Candlepin is deployed in an ISV's hosted environment, and
 has a feed (or calls out to get) Order and Product Data. Then, remote clients
@@ -82,9 +112,6 @@ Clients (called consumers) go through the following standard lifecycle:
 1. Clients can retrieve updated certificates to handle cases where data has changed server side.
 1. Clients can unbind, or stop consuming certificates.
 1. Clients can unregister, or delete themselves from the system.
-
-# Terms
-See the [Candlepin glossary](glossary.html).
 
 # API
 The engine exposes an API over REST. The API [description](api.html) provides details about what can be done.

--- a/docs/candlepin/pool_types.md
+++ b/docs/candlepin/pool_types.md
@@ -1,0 +1,34 @@
+---
+title: Pool Types
+---
+{% include toc.md %}
+
+### Types of Pools
+
+When a subscription object is imported, one or more pools will be created, depending on the attributes of its marketing product.
+
+1. Master Pool
+  * At least one subscription pool will always be created for any subscription. That Pool is called Master Pool
+1. Bonus Pool
+  * Created as the result of an consumption of a pool with a virt_limit attribute (the marketing product of the pool having virt_limit attribute)..
+  * If the marketing product of a pool has a stacking_id, see Stack Bonus Pool below
+  * When a host system binds to a pool with virt_limit, a bonus pool is created for guests *on that host*. Bonus pool will have a pool attribute: requires_host = candlepin host consumer UUID. Access to this pool will be restricted to guests who have been reported as running on that host by virt-who.
+1. Stack Bonus Pool
+  * Similar to a Bonus Pool, only when stacked there is a business requirement that only one bonus pool ever exists for that stack for a given consumer.
+  * When a host first binds to a pool with a given stack ID, a stack derived pool is created.
+  * On subsequent binds to pools with that same stack ID, the stack bonus pool is updated to have merged characteristics of all the pools in the stack
+1. Unmapped Bonus Pool
+  * To help customers struggling with timing issues between when a guest is created and tries to subscribe, and when virt-who reports the host to guest mapping (unlocking the pools for that guest), unmapped bonus pools were added.
+  * These pools are only usable by guest consumers who are less than 24 hours old, and who have not yet been linked to any host.
+  * Entitlements will only be valid for 24h.
+  * As soon as virt-who reports the host guest mapping any entitlements to unmapped bonus pools are revoked.
+    * An auto-bind is then performed on the guest, which includes attempting to attach any pools to the host which will unlock derived sub-pools for something the guest needs.
+1. Virt Bonus Pool
+  * A legacy type of subscription which can exist only in hosted and is no longer used on new SKUs.
+  * Triggered in hosted when marketing SKU specifies a virt_limit attribute but does *not* have host_limited = true.
+  * Pool is created during refresh pools when subscription is first seen, as opposed to as the result of an entitlement as most other derived pools are.
+
+#### Derived Products
+
+Pools can also carry a derived marketing product and derived provided marketing products. These derived products are used in virtualized environment to accomodate scenarios where a host is intended to get access to different (or no) content than the guests. The  master pool will use the marketing product and provided products on the subscription. However any bonus pools or unmapped bonus pools will flip to use the derived marketing product and derived provided products. 
+

--- a/docs/candlepin/product_attributes.md
+++ b/docs/candlepin/product_attributes.md
@@ -1,12 +1,18 @@
 ---
-title: Product Attributes
+title: Subscription Pool and Marketing  Product Attributes
 ---
-# Product Attributes
+# Attributes
+Subscription pools and marketing products have key-value attributes. 
+
+A type of a Subscription is determined by what attributes the marketing product it has. Marketing product attributes have key role in defining the behavior of Candlepin.
+
+On the other hand, the attributes placed on Subscription Pools usually play technical role. In other words, Candlepin is using this attributes as variables to note important things about a Subscription Pool such as with attribute requires_host - which is used to limit usage of a Subscription Pool to a specific consumer. 
+
 
 | Name | Appears On | Possible Values | Purpose | Notes |
 -|-
 | arch | product | ALL, x86_64, i686, x390x | A list of architectures which a subscription can be attached to. All is used to denote all architectures. |
-| host_limited | product | true, false or \<not present\> | Modifies virt_limit behaviour in hosted to create host restricted sub-pools on bind, rather than the one big bonus pool. |
+| host_limited | product | true, false or \<not present\> | Modifies virt_limit behaviour in hosted to create host restricted bonus pools on bind, rather than the one big bonus pool. |
 | instance_multiplier | product | integer | Triggers instance based subscriptions. Multiplies size of the pool, but physical binds will consume entitlements in multiples of this value. |
 | management_enabled | product | 1|0 | Denotes if management is enabled. This value is passed down in the certificate. |
 | multi-entitlement | product | yes,\<not present\> | If yes, a consumer can attach a subscription for this product more than once. If set to anything else or not present, they can't. |
@@ -16,13 +22,14 @@ title: Product Attributes
 | requires_host | pool | Host consumer UUID | Indicates that only guests whose host consumer matches the given UUID can use this subscription.  |
 | sockets | product | number of cpu sockets | The number of sockets which a subscription can cover. |
 | support_level | product | human readable description of support level | Used to match a usrs preference to make a machine a certain support level. |
+| storage_band | product | 1 or 0 | 1 if and only if the marketing product is to be used to cover CEPH software. |
 | support_type | product | human readable description of support type | Passed down to the certificate. |
 | user_license | product | "unlimited", int | Indicates that when an entitlement is granted, a new pool is created of the indicated size, which is only available to consumers registered by the same user account. This is used to model "developer subscriptions"  |
 | user_license_product | product | product ID | Indicates what product the new pool should be for in the above scenario. If not specified, the same product is used from the original subscription/pool. |
 | variant | product | product variant | This value is passed down to the certificate. |
 | version | product | product version | This value is passed down to the certificate. |
 | virt_only | product, pool | true, \<not present\> | If true, a susbcription can only be attached to a virtual machine |
-| virt_limit | product, pool | number | Indicates a number of guests an subscription includes. This behavior varies depending on whether or not the server is configured for standalone. If in standalone, an entitlement creation will create a sub-pool restricted to only guests on that host. In hosted, a single virt pool is created during refresh pools for floating guests with no restrictions on which host they are on, nor any requirement that the host be registered and subscribed beforehand. |
+| virt_limit | product, pool | number | Indicates a number of guests an subscription includes. This behavior varies depending on whether or not the server is configured for standalone. If in standalone, an entitlement creation will create a bonus pool restricted to only guests on that host. In hosted, a single virt pool is created during refresh pools for floating guests with no restrictions on which host they are on, nor any requirement that the host be registered and subscribed beforehand. |
 | stacking_id | product | string | An arbitrary string which creates a functional equivilance across different products. This is used with multi-entitlement to allow combining many subscriptions. |
 | warning_period | product | number | The number of days prior to expirey where the client should warn that a subscription will soon expire. |
 {:.table-striped .table-bordered}

--- a/docs/candlepin/product_attributes.md
+++ b/docs/candlepin/product_attributes.md
@@ -22,7 +22,7 @@ On the other hand, the attributes placed on Subscription Pools usually play tech
 | requires_host | pool | Host consumer UUID | Indicates that only guests whose host consumer matches the given UUID can use this subscription.  |
 | sockets | product | number of cpu sockets | The number of sockets which a subscription can cover. |
 | support_level | product | human readable description of support level | Used to match a usrs preference to make a machine a certain support level. |
-| storage_band | product | 1 or 0 | 1 if and only if the marketing product is to be used to cover CEPH software. |
+| storage_band | product | 1 or 0 | 1 if and only if the marketing product is to be used to cover disk storage software. |
 | support_type | product | human readable description of support type | Passed down to the certificate. |
 | user_license | product | "unlimited", int | Indicates that when an entitlement is granted, a new pool is created of the indicated size, which is only available to consumers registered by the same user account. This is used to model "developer subscriptions"  |
 | user_license_product | product | product ID | Indicates what product the new pool should be for in the above scenario. If not specified, the same product is used from the original subscription/pool. |

--- a/docs/candlepin/products_and_subscriptions.md
+++ b/docs/candlepin/products_and_subscriptions.md
@@ -1,0 +1,116 @@
+---
+title: Products, Subscriptions and Entitlements
+---
+{% include toc.md %}
+
+
+The ultimate goal of an owner is to use a piece of software on theirs *consumers*. 
+
+The diagram below shows simplified example of Candlepin usage. The owner, organization Mediatechnology, owns two developer machines (consumers) that need to use Fedora 22 and JBoss Application Server. The Mediatechnology can buy a subscription named "Java Developer Subscription" that provides "Marketing_Java_Dev_Product", this Marketing Product in turn provides the two required Engineering Products. Candlepin helps in this situation by bookkeeping information about: 
+
+* the owner (name, credentials to log in into Candlepin)
+* the consumers (developer machines). Information about installed software is also tracked, they are so called *facts*: CPUs, amount of RAM, etc.
+* subscription that the owner bought
+* *consumption* of a subscription for each given developer machine. The act of consumption and the object that tracks the consumption is called Entitlement
+
+Based on the above information, Candlepin can easily determine which consumers (developer machines) for owner Mediatechnology are sufficiently covered and which lack necessary subscriptions.
+
+The diagram is still very incomplete, at the end of this page, this diagram will be extended to more accurately align with how Candlepin works
+
+{% plantuml %}
+actor owner_Mediatechnology
+frame Java_Developer_Subscription {
+  artifact Marketing_Java_Dev_Product  
+  artifact JBoss_Application_Server
+  artifact Fedora_22
+  Marketing_Java_Dev_Product -->  JBoss_Application_Server : provides
+  Marketing_Java_Dev_Product -->  Fedora_22 : provides
+}
+artifact JBoss_Application_Server
+artifact Fedora_22
+node Developer_machine_1
+node Developer_machine_2
+owner_Mediatechnology --> Java_Developer_Subscription : buys
+owner_Mediatechnology --> Developer_machine_1 : owns
+owner_Mediatechnology --> Developer_machine_2 : owns
+{% endplantuml %}
+
+
+## Engineering and Marketing Products
+We have already seen examples of Engineering Product:
+
+* JBoss Application Server
+* Fedora 22
+
+These Engineering Products have numeric IDs in Candlepin (e.g. 23) to identify them. Each engineering product is also tied with Content. A Content is a set of Content Repositories such as YUM repositories that contain the product binaries or related software. 
+
+Engineering Products are tied to so called Marketing Products. This is done to bundle more Engineering Product together under one Marketing Product. Marketing Products have key-value attributes  which control the business logic in Candlepin. An example of attribute is an integer valued attribute 'sockets'. The value of this attribute specifies maximum amount of CPU cores that a consumer is allowed to have when using the Marketing Product. The Marketing products have alpha-numeric ID also reffered to as SKU (e.g. MKT22321) and carry no Content. 
+
+Another concepts in Candlepin are: *Derived Marketing Product* and *Derived Engineering Product*. These are special usages of Marketing/Engineering products in virtualized environment. In Virtualized Environment, Candlepin can distinguish between host consumers (computers that act as Hypervisors in virtualization) and guest systems (virtual machines that are provisioned on the Hypervisors). In some specific cases, it might be desireable that the guest systems will not directly use the Marketing Product that a customer bought with a subscription, but the subscription has another so called Derived Marketing Product that is dedicated to be used for the guest system. 
+
+## Subscriptions
+Subscription is a right to use a given Marketing Product. The subscription bundles:
+
+* Marketing Product
+* Provided Engineering Products
+* (optional) Derived Marketing Product
+* (optional) Provided Derived Engineering Products
+
+There are different types of Subscriptions. The type of the Subscription is not explicitly stored in any transfer object, but it is an abstract property of Subscription that can be infered from attributes that the bundled Marketing Product contains. The most common types of the Subscriptions are: Plain, Stacked, Virt Limit, Instance Based, Storage Band, Derived. More information about the types can be found [here](subscription_types.html)
+
+Subscriptions are created in Candlepin by the administrator. In Standalone deployment of Candlepin, the administrator uses so called Subscription Adapter to load Subscriptions into Candlepin. 
+
+## Subscription Pool
+It might be suprising that Candlepin doesn't actually store Subscriptions databse. The actual object that Candlepin stores in the database is called Subscription Pool.
+
+Subscription Pool (also referred to simply as a Pool) is very similar to Subscription. Pool is also a right to use a given Marketing Product and the Pool also bundles Products in very much the same way as Subscription does. The reason we store Subscription Pool instead of Subscription is mainly technical. However it should be clear that apart from the administrators import of Subscription, Candlepin does not perform business logic on the Subscriptions, but it only uses Subscription Pools.
+
+For each subscription that the administrator defines, at least one Subscription Pool is created in Candlepin. Pools can be of different types based on how the they are created. The pool type is recorded as a database flag. Basic types include: Master Pool, Derived Pool, Stack Derived Pool, Unmapped Guest Pool, Virt Bonus Pool. You can find list of pool types [here](pool_types.html)
+
+## Entitlement
+Entitlement represents a consumption of a pool for a given consumer. The consumption takes place at a specific time. Note that the Subscription Pool has integer value *quantity* and consumption decreases the quantity of the Pool. 
+
+An entitlement can be revoked, which returns the used quantity back to the pool and removes the entitlement object from the Candlepin database.
+
+The consumption of a Subscription Pool is done, like most of the interactions with Candlepin, using a REST API call. However, the end-user typically uses one of more user friendly interfaces such as Python based thick client called Subscription Manager. The Subscription Manager is invoked directly from the system (consumer). The Subscription Manager can detect installed Engineering Products on the machine and thus can make it is easier for the user to choose which Pools to consume. This process is called *manual attach* of a subscription pool. 
+Another possibility to consume a Pool is *auto attach*. Invoking this operation for a given consumer causes Candlepin server to attempt to find the best fit of available subscription pools to cover the consumer’s installed engineering products. Note that prior to running this operation, it is necessary that the information about installed engineering products is provided to Candlepin. The information may be provided by Subscription Manager.
+
+## Example
+The following diagram shows a basic situation where owner Mediatechnology buys a Java Developer Subscription. That subscription triggers creation of a new master Subscription Pool: *Java Dev Pool*. In this example, Mediatechnology has two consumers, that want to consume the Pool. The Java Developer Subscription is of type *plain* which means that Java Dev Pool will need to have at least quantity of 2 so that both consumers dev1 and dev2 are satisfied. The two consumptions of the Java Dev Pool will cause creation of two entitlements in Candlepin: Entitlement1 and Entitlement2. Each entitlement is tied to the specific Pool and to a specific Consumer.
+
+
+{% plantuml %}
+actor owner_Mediatechnology
+
+frame Java_Developer_Subscription {
+  artifact Mkt_Product_Java_Dev_Sub
+  artifact Engineering_Prod_JBoss_AS
+  artifact Engineering_Prod_Fedora_22
+  Mkt_Product_Java_Dev_Sub --> Engineering_Prod_JBoss_AS : provides
+  Mkt_Product_Java_Dev_Sub --> Engineering_Prod_Fedora_22 : provides
+}
+
+frame Java_Dev_Pool {
+  artifact Mkt_Product_Java_Dev_Pool
+  artifact Eng_Product_JBoss_AS
+  artifact Eng_Product_Fedora_22
+  Mkt_Product_Java_Dev_Pool --> Eng_Product_JBoss_AS : provides
+  Mkt_Product_Java_Dev_Pool --> Eng_Product_Fedora_22 : provides
+}
+
+node Consumer_dev1
+node Consumer_dev2
+owner_Mediatechnology --> Java_Developer_Subscription : buys
+Java_Developer_Subscription --> Java_Dev_Pool : causes creation of
+owner_Mediatechnology --> Consumer_dev1 : owns
+owner_Mediatechnology --> Consumer_dev2 : owns
+artifact Entitlement1
+artifact Entitlement2
+Consumer_dev1 --> Java_Dev_Pool : consumes
+Consumer_dev1 --> Entitlement1 : consumption created
+Entitlement1 --> Java_Dev_Pool : decreases quantity of
+Consumer_dev2 --> Java_Dev_Pool : consumes
+Consumer_dev2 --> Entitlement2 : consumption created
+Entitlement2 --> Java_Dev_Pool : decreases quantity of
+{% endplantuml %}
+

--- a/docs/candlepin/storage_band_subscriptions.md
+++ b/docs/candlepin/storage_band_subscriptions.md
@@ -5,30 +5,7 @@ title: Storage Band Subscription
 
 # Storage Band Subscription Implementation
 
-## Storage Band (Ceph) SKU
-
-The SKU (marketing product) should be defined such that it makes use of the product multiplier in order to provide enough entitlements to cover the total capacity of all nodes in TB. Each entitlement will equate to 1TB of coverage and marketing products will use the multiplier such that "sub_quantity_purchased x multiplier" will yield pool quantity (total capacity in TB).
-
-
-Consider the following SKU definition (note that multiplier is NOT a product attribute) and a customer who bought 1 subscription.
-
-    multiplier: 512
-    stacking_id: product_stack_id
-    mutli-entitlement: yes
-    storage_band: 1
-
-
-    pool_quantity = sub_qty_bought * multiplier
-                  = 1 * 512
-                  = 512
-
-
-The resulting pool will have a quantity of 512, which can cover 512TB of storage (across multiple nodes/systems).
-
-
-
-**NOTE:** The “storage_band” attribute is enables storage counting. It is important to note that this is NOT an on/off switch. To the rules framework, this is the value of a single entitlement (or how the entitlement will be evaluated for coverage) and it will be used to determine coverage of a consumer. For CEPH, this will equate to 1TB per entitlement.  Thus the user must “stack” on enough 1 TB entitlements to cover the storage capacity on the system assigned to Ceph.
-
+These are implementation details of [Storage Band Subscription Type](subscription_types.html)
 
 ## Generating Status (Rules)
 

--- a/docs/candlepin/subscription_types.md
+++ b/docs/candlepin/subscription_types.md
@@ -3,7 +3,7 @@ title: Subscription Types
 ---
 {% include toc.md %}
 
-Candlepin supports a number of different subscription types which are defined by the attributes on the marketing/SKU product on the subscription. You can view the list of [product attributes](product_attributes.html), this document will outline at a higher level how they can be combined to create the various major types of subscriptions Candlepin supports.
+Candlepin supports a number of different subscription types which are defined by the attributes on the marketing product that is bundled in the subscription. You can view the list of [product attributes](product_attributes.html), this document will outline at a higher level how they can be combined to create the various major types of subscriptions Candlepin supports.
 
 ## Plain
 
@@ -26,13 +26,13 @@ CPU socket stacking is by far the most common, but Candlepin also supports stack
 
 ## Virt Limit
 
-Virt limit subscriptions are used to entitle a physical host, as well as some quantity of guests running on that specific host.
+Virt limit subscriptions are used in virtualized environment. To entitle a host, as well as some quantity of guests running on that specific host.
 
 Example:
 
  * virt_limit: 4 / unlimited
 
-When a physical host consumes a virt_limit subscription, a sub-pool is created that is only visible/usable by guests who are running on that host. The virt-who utitlity is typically what reports the host/guest mapping information and allows this functionality to work. Revoking the physical host entitlement will result in revoking the sub-pool and all it's existing entitlements.
+When a host consumes a virt_limit subscription, a sub-pool is created that is only visible/usable by guests who are running on that host. The virt-who utitlity is typically what reports the host/guest mapping information and allows this functionality to work. Revoking the physical host entitlement will result in revoking the sub-pool and all it's existing entitlements.
 
 Note that guests can still consume the main pool, provided the product does not also carry the physical_only attribute.
 
@@ -56,6 +56,24 @@ The subscriptions cannot be broken down for physical systems if they were to hav
 
 i.e. A physical system with 8 sockets will require quantity 8 (system sockets / product sockets * instance_multiplier)
 
+## Storage Band 
+Storage Band Subscriptions are used to cover CEPH (distributed file system) software solutions. Marketing product of such subscription contains storage_band attribute and integer valued *multiplier* property (not an attribute but actual property of a product). The total quantity of Subscription Pool that is created from Storage Band subscription is calculated as follows
+
+```
+ pool_quantity = subscription_qty * mkt_product_multiplier 
+```
+
+It is also required that Marketing Products of Storage Band Subscription have the following attributes set:
+
+```
+storage_band=1
+multi-entitlement='yes'
+stacking_id: <some_product_stack_id>
+```
+
+The fact that Storage Band Subscriptions are multi-entitlement and that they have stacking_id means that its easy to cumulatively cover the storage space. 
+
+One quantity of Subscription Pool means coverage of 1 TB of CEPH storage capacity. So for example Subscription that has marketing product with multilier 512 can be used to sell multiples of 512 TB of CEPH storage.
 
 ## Derived
 

--- a/docs/candlepin/subscription_types.md
+++ b/docs/candlepin/subscription_types.md
@@ -57,7 +57,7 @@ The subscriptions cannot be broken down for physical systems if they were to hav
 i.e. A physical system with 8 sockets will require quantity 8 (system sockets / product sockets * instance_multiplier)
 
 ## Storage Band 
-Storage Band Subscriptions are used to cover CEPH (distributed file system) software solutions. Marketing product of such subscription contains storage_band attribute and integer valued *multiplier* property (not an attribute but actual property of a product). The total quantity of Subscription Pool that is created from Storage Band subscription is calculated as follows
+Storage Band Subscriptions are used to cover file system subscriptions where an owner wants to cover certain amount of disk space for a consumer. Example of such software solution is CEPH. Marketing product of such subscription contains storage_band attribute and integer valued *multiplier* property (not an attribute but actual property of a product). The total quantity (disk space) of Subscription Pool that is created from Storage Band subscription is calculated as follows
 
 ```
  pool_quantity = subscription_qty * mkt_product_multiplier 
@@ -71,9 +71,10 @@ multi-entitlement='yes'
 stacking_id: <some_product_stack_id>
 ```
 
+One quantity of Storage Band Subscription Pool means coverage of 1 TB of storage capacity. So Subscription that has marketing product with multilier 512 can be used to sell multiples of 512 TB of storage.
+
 The fact that Storage Band Subscriptions are multi-entitlement and that they have stacking_id means that its easy to cumulatively cover the storage space. 
 
-One quantity of Subscription Pool means coverage of 1 TB of CEPH storage capacity. So for example Subscription that has marketing product with multilier 512 can be used to sell multiples of 512 TB of CEPH storage.
 
 ## Derived
 

--- a/docs/candlepin/virtualization_entitlements.md
+++ b/docs/candlepin/virtualization_entitlements.md
@@ -1,5 +1,5 @@
 ---
-title: Virtualization Entitlements
+title: Virtualization 
 ---
 This page may be out of date
 {:.alert-bad}


### PR DESCRIPTION
Updating introduction to Subscriptions, Products, Entitlements. Introducing more examples and forming more flowing narrative in our documentation. Also unified some basic terminology. 

Note the introduction will need more refinement in the next sprints, mostly the Overview page seems a bit outdated.
