### PR TITLE
Updated the documentation associated with the CP2 migration details

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,3 @@ DEPENDENCIES
   stringex
   thin
   typogruby
-
-BUNDLED WITH
-   1.11.2

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -68,7 +68,7 @@
     subs:
       - section: architecture
         subs:
-          - section: per_org_products
+          - section: cp2_migration
           - section: pinsetter
           - section: batch_engine
           - section: event_model
@@ -92,7 +92,7 @@
           - section: hibernate
       - section: implementation_details
         subs:
-          - section: revoke_entitlements_implementation 
+          - section: revoke_entitlements_implementation
       - section: debugging
         subs:
           - section: cpc_tips

--- a/docs/candlepin/cp2_migration.md
+++ b/docs/candlepin/cp2_migration.md
@@ -1,5 +1,5 @@
 ---
-title: Per-Org Products
+title: Candlepin 2.0 Migration
 ---
 {% include toc.md %}
 
@@ -11,7 +11,7 @@ Candlepin 2.0 will involve a massive data model change affecting how products, s
 
  1. A large upgrade process is provided which will migrate all existing data to each org that uses it.
  1. Product data will now always be cached in Candlepin's database, it is no longer queried from service adapters in production.
- 1. Each org which uses a product will receive it's own copy of that product. A product will exist only once in an org.
+ 1. Each org which uses a product will have its own copy of that product. A product will exist only once in an org.
  1. Subscriptions as a model object will no longer be in Candlepin's database. They are used only as transient objects during import.
  1. Manifest import and refresh pools have been largely combined into one operation. Importing will bring in both the customers latest subscriptions and product data, not just one or the other.
  1. Custom subscriptions are no longer necessary, you can create custom pools directly for custom content you wish to expose.
@@ -29,9 +29,9 @@ Candlepin 2.0 will involve a massive data model change affecting how products, s
 
 To facilitate storing products and product content in a per-org manner, several changes to the database and object model have been made. While the normal deployment process will make these changes automatically, any existing tooling and/or scripts will need to be updated in accordance with the changes listed below.
 
- 1. Several per-org versions of existing tables are created. These tables are created with a "cpo\_" prefix rather than the "cp\_" prefix. The new tables also somewhat standardize table name pluralization and column name underscore usage. Affected tables include: *cp\_activation\_key\_product, cp\_branding, cp\_content, cp\_content\_modified\_products, cp\_env\_content, cp\_installed\_products, cp\_pool\_branding, cp\_pool\_products, cp\_pool\_source\_sub, cp\_product\_attribute, cp\_product\_certificate, and cpo\_product
+ 1. Several per-org versions of existing tables are created. These tables are created with a "cp2\_" prefix rather than the "cp\_" prefix. The new tables also somewhat standardize table name pluralization and column name underscore usage. Affected tables include: *cp\_activation\_key\_product, cp\_branding, cp\_content, cp\_content\_modified\_products, cp\_env\_content, cp\_installed\_products, cp\_pool\_branding, cp\_pool\_products, cp\_pool\_source\_sub, cp\_product, cp\_product\_attribute, and cp\_product\_certificate
  1. *cp\_pool* is updated with several new fields to hold information previously owned by subscriptions.
- 1. For each organization, existing products referenced by pools or subscriptions owned by the current organization are copied to the new *cpo\_products* table with a reference to the new org and a new UUID. Any reference within the database to a product is made using the UUID with enforced referential integrity.
+ 1. For each organization, existing products referenced by pools or subscriptions owned by the current organization are copied to the new *cp2\_products* table with a reference to the new org and a new UUID. Any reference within the database to a product is made using the UUID with enforced referential integrity.
  1. Any per-product data are then copied to the new per-org tables for each product in the current organization. This currently includes product attributes and content, certificates and activation keys.
  1. Next, per-org pool data, such as branding, are migrated.
  1. Finally, data which were previously only associated with subscriptions are migrated to the new fields in *cp\_pool*. This includes upstream object references, subscription certificates and CDN details.
@@ -72,7 +72,9 @@ To begin, make sure the local database is populated by running the "populate DB"
 required in hosted environments and will no-op in standalone environments, so it's safe to do if
 you're unsure whether or not it's necessary.
 
-```curl -k -u admin:admin "https://localhost:8443/candlepin/admin/pophosteddb"```
+```
+curl -k -u admin:admin "https://localhost:8443/candlepin/admin/pophosteddb"
+```
 
 Wait a bit for the task to finish (or periodically check the job status via /jobs/{job_id}),
 then take a snapshot of the environment with the [cmv](cmv.html) utility.
@@ -82,21 +84,31 @@ cd ~/devel/candlepin/server
 ./bin/cmv snapshot
 ```
 
+**Note:** The cmv utility operates by caching the received JSON for later comparison. Depending on the size of
+your data set, it may require a large amount of disk space to snapshot the entire deployment. For comparison,
+a snapshot of the Candlepin test data is around 900 kib for three organizations with 85 products and 25
+contents.
+{:.alert-notice}
+
+
 Once the snapshot is finished, a normal upgrade can be done via the deploy script.
 
-```./bin/deploy```
+```
+./bin/deploy
+```
 
 
 Finally, the migration can be verified with the cmv tool. While cmv can be run without any
 parameters, there are several expected changes/warnings that can be safely ignored (more on this
 below). To exclude all the expected warnings, the following command can be used:
 
-```./bin/cmv --exclude orgs.pools.productAttributes.created --exclude orgs.pools.productAttributes.updated --exclude orgs.pools.derivedProductAttributes.created --exclude orgs.pools.derivedProductAttributes.updated --exclude orgs.pools.derivedProduct --exclude orgs.pools.upstreamPoolId --exclude orgs.pools.upstreamEntitlementId --exclude orgs.pools.upstreamConsumerId --exclude orgs.pools.cdn --exclude orgs.pools.product --exclude orgs.pools.providedProducts.id --exclude orgs.pools.providedProducts.created --exclude orgs.pools.providedProducts.updated --exclude orgs.pools.derivedProvidedProducts.id --exclude orgs.pools.derivedProvidedProducts.created --exclude orgs.pools.derivedProvidedProducts.updated --exclude orgs.pools.productAttributes.id --exclude orgs.pools.productAttributes.productId --exclude orgs.pools.derivedProductAttributes.id --exclude orgs.pools.derivedProductAttributes.productId --exclude orgs.products.href --exclude orgs.products.owner --exclude orgs.products.uuid --exclude orgs.products.productContent.content.uuid --exclude orgs.products.productContent.content.owner verify```
+```
+./bin/cmv verify --exclude orgs.pools.providedProducts.id --exclude orgs.pools.providedProducts.created --exclude orgs.pools.providedProducts.updated --exclude orgs.pools.productAttributes.id --exclude orgs.pools.productAttributes.productId --exclude orgs.pools.productAttributes.created --exclude orgs.pools.upstreamPoolId --exclude orgs.pools.upstreamEntitlementId --exclude orgs.pools.upstreamConsumerId --exclude orgs.products.uuid --exclude orgs.products.href --exclude orgs.products.productContent.content.uuid --exclude orgs.pools.derivedProductAttributes --exclude orgs.pools.derivedProductAttributes.id --exclude orgs.pools.derivedProductAttributes.productId --exclude orgs.pools.derivedProductAttributes.created --exclude orgs.pools.derivedProductAttributes.updated --exclude orgs.pools.derivedProvidedProducts.id --exclude orgs.pools.derivedProvidedProducts.created --exclude orgs.pools.derivedProvidedProducts.updated
+```
 
 With this command, the verification should complete without any errors or warnings. If so, the
 migration was completed successfully. Otherwise, steps may be necessary to manually complete the
 migration, or it may be necessary to roll back and try again.
-
 
 
 ## Expected CMV Warnings
@@ -105,51 +117,38 @@ As noted above, there are several expected changes that will show up in a vanill
 migration to Candlepin 2.0. Most are related to minor changes in the JSON returned by API calls,
 while a few others relate to precision issues with the migration to new database tables.
 
-- orgs.pools.productAttributes.created
-- orgs.pools.productAttributes.updated
-- orgs.pools.derivedProductAttributes.created
-- orgs.pools.derivedProductAttributes.updated
+* orgs.pools.providedProducts
+* orgs.pools.derivedProvidedProducts
 
-Dates are off by a few seconds due to a loss of precision between the DB and the migration tool
+The providedProducts and derivedProvidedProducts fields used to be populated directly by Candlepin's internal
+model objects, all of which have an ID and created and updated timestamp fields. With the migration to
+Candlepin 2.0, some collection objects have been converted to DTOs which lack these fields. As a result, the
+id, created and updated fields are no longer present in the API response.
 
-- orgs.pools.derivedProduct
-- orgs.pools.upstreamPoolId
-- orgs.pools.upstreamEntitlementId
-- orgs.pools.upstreamConsumerId
-- orgs.pools.cdn
+* orgs.pools.productAttributes
+* orgs.pools.derivedProductAttributes
 
-These are new fields migrated from the old subscription model object; they will not exist in the
-snapshot data
+The product attribute values no longer include internal-use model details such as the ID and raw timestamps
+for created and updated times. Instead, the timestamps provided are standardized timestamps which no longer
+include milliseconds.
 
-- orgs.pools.product
+* orgs.products.uuid
+* orgs.products.productContent.content.uuid
 
-Pools now maintain a reference to the product, rather than just the product ID. As such, this field
-will not exist in the snapshot data
+In the transition to per-organization products and content, both objects received a new identifier to allow
+multiple organizations to represent different states of the same products. This field is not currently used
+for any API requests and may be removed from output in future versions.
 
-- orgs.pools.providedProducts.id
-- orgs.pools.providedProducts.created
-- orgs.pools.providedProducts.updated
-- orgs.pools.derivedProvidedProducts.id
-- orgs.pools.derivedProvidedProducts.created
-- orgs.pools.derivedProvidedProducts.updated
+* orgs.products.href
 
-The provided products collections on a pool is now maintained by links to actual product references,
-eliminating the need for a special object and its id, created and updated fields
+With products now being per-organization, the URL used to refer back to a given product has been updated to
+also include the owning organization in the URL. This change is now reflected in the product JSON.
 
-- orgs.pools.productAttributes.id
-- orgs.pools.productAttributes.productId
-- orgs.pools.derivedProductAttributes.id
-- orgs.pools.derivedProductAttributes.productId
 
-Like the provided products field, product attributes on a pool is provided directly, rather than
-through a secondary/join object. The id and productId fields will no longer be present as a result.
+* orgs.pools.upstreamPoolId
+* orgs.pools.upstreamEntitlementId
+* orgs.pools.upstreamConsumerId
 
-- orgs.products.href
-- orgs.products.owner
-- orgs.products.uuid
-- orgs.products.productContent.content.uuid
-- orgs.products.productContent.content.owner
-
-Products and Content are now per-org, and now require a reference to their owner (organization), and
-a new uuid field. These won't exist in the snapshot data. Additionally, the Product's href field now
-includes the owner information.
+In Candlepin 2.0, the subscription object has been relegated to a transient DTO used only during pool refresh
+and manifest import. These fields, which point back to upstream data sources, have been moved to the pool
+object.


### PR DESCRIPTION
- Updated the affected and new database table names to reflect the
  new names and additional changes
- Updated the list of expected CMV warnings and their explanations
- Renamed the cp2 per-org products document to cp2 migration