### PR TITLE
Pin bundler to a working version.

### DIFF
--- a/.openshift/action_hooks/pre_build
+++ b/.openshift/action_hooks/pre_build
@@ -7,5 +7,5 @@ pushd $OPENSHIFT_REPO_DIR
 
 # We need a recent version of Bundler to support the
 # "ruby" keyword in the Gemfile.
-gem update bundler
+gem install bundler --version 1.11.2
 popd


### PR DESCRIPTION
There's a regression in 1.12.1 that causes an error in OpenShift
deployments: Bundler tries to write to a .bundle directory underneath
the home directory which is read-only in OpenShift.