### PR TITLE
Reviewer should change the state of the bugzilla during review.

### DIFF
--- a/docs/candlepin/bugzilla_process.md
+++ b/docs/candlepin/bugzilla_process.md
@@ -11,10 +11,9 @@ title: Bugzilla process
  * Before the reviewer starts to review the pull request, the reviewer assigns the pull request to self, and adds the `Needs Second Review` label if necessary.
  * After the pull request is merged to master,
    * the reviewer deletes the branch used for the PR.
-   * the author of the pull request changes the state of the upstream bug to `MODIFIED`.
-   * the author of the pull request changes the state of the downstream bug ( if any ) to `POST`.
+   * the reviewer changes the state of the upstream bug to `MODIFIED`.
+   * the reviewer changes the state of the downstream bug ( if any ) to `POST`.
    * the author of the pull request deletes the branch used for the PR if the reviewer missed it.
  * After a brew build has been created, the release nanny:
    * Changes the state to `CLOSED` - currentrelease
    * Adds the RPM build version to the fixed-in-version field of the bug.
-


### PR DESCRIPTION
IMO it is less context switching and less chance for something to fall through the cracks if the reviewer is the one to change the state of any linked bugzilla bug to a PR once they have merged a PR to master.
