### PR TITLE
Force site regeneration every time Rack starts.

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -13,4 +13,7 @@ use Rack::Rewrite do
   moved_permanently %r{(/.*/)((?!.+?\.|.+/$).+)}, '$1$2/'
 end
 
-run Rack::Jekyll.new(:auto => false)
+# force_build will have Jekyll regenerate the site every time Rack is started.
+# This means that we can simply restart the OpenShift app to force a refresh
+# rather than require a redeployment.
+run Rack::Jekyll.new(:auto => false, :force_build => true)


### PR DESCRIPTION
I've seen several cases where rack-jekyll gets wedged into thinking that
Jekyll is performing the rendering step when it's actually not doing
anything.  This change will just have rack-jekyll always render the site
on start up so there shouldn't be any more false positives about whether
the site is rendering or not.