### PR TITLE
Change sub-man BZ process to be more aligned with candlepin

### DIFF
--- a/docs/candlepin/bugzilla_process.md
+++ b/docs/candlepin/bugzilla_process.md
@@ -5,13 +5,15 @@ title: Bugzilla process
 
 # Bugzilla process
 
- * A developer picks a bug in the order of priority and severity, and "takes" it ( `assigns` it to one's self )
- * All pull requests against a bug filed in bugzilla must have a commit message of the format "BUGID: Description"
+ * A developer picks a bug in the order of priority and severity, and:
+   * changes the state of the bug to `ASSIGNED`
+   * "takes" it ( `assigns` it to one's self )
+* All pull requests against a bug filed in bugzilla must have a commit message of the format "BUGID: Description"
  * Once the developer is done working and has submitted a pull request for the same, the developer adds a github tracker on the bug to link the pull request ( format: candlepin/candlepin/pull/PR_NUMBER ), and changes the state of the bug to `POST`
  * Before the reviewer starts to review the pull request, the reviewer assigns the pull request to self, and adds the `Needs Second Review` label if necessary.
  * After the pull request is merged to master,
    * the reviewer deletes the branch used for the PR.
-   * the reviewer changes the state of the upstream bug to `MODIFIED`.
+   * the reviewer changes the state of the Candlepin project bug to `MODIFIED`.
    * the reviewer changes the state of the downstream bug ( if any ) to `POST`.
    * the author of the pull request deletes the branch used for the PR if the reviewer missed it.
  * After a brew build has been created, the release nanny:

--- a/docs/subscription-manager/bugzilla_process.md
+++ b/docs/subscription-manager/bugzilla_process.md
@@ -10,12 +10,13 @@ title: Bugzilla process
    * "takes" it ( `assigns` it to one's self )
    * Checks if the bug is dev-ack-ed appropriately
  * Commit messages must be of the format "BUGID: Description"
- * Once the developer is done working and has submitted a pull request for the same, the developer adds a github tracker on the bug to link the pull request ( format: candlepin/subscription-manager/pull/PR_NUMBER ).
- * If the release split[1] has already happened:
-   * After the pull request is merged to master, the author of the pull request changes the state of the bug to `POST`. The release nanny will change the state to `MODIFIED` after cherry-picking your commits.
-   * else, after the pull request is merged to master, the author of the pull request changes the state of the bug to `MODIFIED`.
+ * Once the developer is done working and has submitted a pull request for the same:
+   * The developer adds a github tracker on the bug to link the pull request ( format: candlepin/candlepin/pull/PR_NUMBER ).
+   * The developer changes the state of the bug to `POST`
+ * Before the reviewer starts to review the pull request, the reviewer assigns the pull request to self, and adds the `Needs Second Review` label if necessary.
+ * After the pull request is merged to master,
+   * the reviewer deletes the branch used for the PR.
+   * the reviewer changes the state of the bug to `MODIFIED`.
+   * the author of the pull request deletes the branch used for the PR if the reviewer missed it.
  * After a brew build has been created and tagged as a rhel-X-candidate, the release nanny will add the bug to the appropriate errata and it will automatically be flipped to `ON_QA`.
  * After a bug has been `VERIFIED`, the release nanny updates the fixed-in-version field of the bug. ( to be automated soon )
-
-[1] Release split: the moment when we cut a release branch off of master, after which we would need to start cherry-picking release candidates.
-


### PR DESCRIPTION
Update the BZ process so that from an development engineer perspective there is no difference in the new/assigned/post/modified states between candlepin & sub-man other than the flags. 