### PR TITLE
Update Nokogiri to resolve CVE-2017-9050

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,10 +50,10 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     multi_json (1.12.1)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.0)
@@ -98,4 +98,4 @@ DEPENDENCIES
   typogruby
 
 BUNDLED WITH
-   1.15.4
+   1.16.1


### PR DESCRIPTION
Our site is completely static and nokogiri is only used in the build
process.  But updating the version removes a warning that GitHub shows
and is the right thing to do anyway.