### PR TITLE
Update qpid event monitor/drain instructions

### DIFF
--- a/docs/candlepin/amqp.md
+++ b/docs/candlepin/amqp.md
@@ -47,12 +47,12 @@ In [Katello](http://www.katello.org/) and Satellite deployments Candlepin is con
 * Add an events queue
 
   ```console
-  $ qpid-config add exchange topic events --durable
+  $ qpid-config add exchange topic event --durable
   ```
   If you are connecting to Qpid over SSL, the command will look something like
 
   ```console
-  $ qpid-config --ssl-certificate /path/to/client_cert --ssl-key /path/to/client_key -b amqps://localhost:5671 add exchange topic events --durable
+  $ qpid-config --ssl-certificate /path/to/client_cert --ssl-key /path/to/client_key -b amqps://localhost:5671 add exchange topic event --durable
   ```
 * Configure candlepin
 
@@ -74,24 +74,29 @@ In [Katello](http://www.katello.org/) and Satellite deployments Candlepin is con
   ```console
   $ sudo service tomcat6 restart
   ```
-* Hook up a client (like Qpid's [Python drain](http://qpid.apache.org/releases/qpid-0.26/messaging-api/python/examples/drain.html) or [Java drain](http://qpid.apache.org/releases/qpid-0.24/qpid-jms/examples/Drain.java.html)).
-
-
+* Use our client in `server/bin/qpid_watch.py` to monitor and/or drain events. Alternatively, you can use Qpid's [Python drain](https://qpid.apache.org/releases/qpid-python-1.37.0/messaging-api/examples/drain) or [Java drain](https://qpid.apache.org/releases/qpid-java-6.0.2/qpid-jms/examples/Drain.java).
 
 ## Verify it's working
 
 Here's the old method that worked **without** SSL:
 
 * Install python-qpid >= 0.7 (you can get it from pulp's yum repo)
-* Download <https://svn.apache.org/repos/asf/qpid/trunk/qpid/python/examples/api/drain>
+* Download <https://qpid.apache.org/releases/qpid-python-1.37.0/messaging-api/examples/drain>
 * Run
 
   ```python
-  python drain -f "events/"
+  python drain -f "event/"
   ```
 * Run some of candlepin's functional tests, and watch the messages fly!
 
-With SSL, the best I've found is to use the Java client example, which needs a full checkout of qpid:
+With SSL, the most convenient way to monitor and/or drain events is to use our own client found in `server/bin/qpid_watch.py`:
+
+```console
+$ cd server/
+$ bin/qpid_watch.py -c bin/qpid/keys/qpid_ca.crt -k bin/qpid/keys/qpid_ca.key -s event --timeout -1 --show-message --drain
+```
+
+Alternatively, you could use the Java client example, which needs a full checkout of qpid:
 
 * Checkout code.
 
@@ -108,7 +113,7 @@ With SSL, the best I've found is to use the Java client example, which needs a f
 
   ```console
   $ cd build/lib
-  $ java -classpath `build-classpath-directory .` -Djavax.net.ssl.trustStore=/etc/candlepin/certs/amqp/candlepin.truststore -Djavax.net.ssl.keyStore=/etc/candlepin/certs/amqp/candlepin.jks -Djavax.net.ssl.keyStorePassword=password -Djavax.net.ssl.trustStorePassword=password org.apache.qpid.example.Drain --broker=guest:guest@localhost:5671 --broker-option=ssl=true,ssl_cert_alias=amqp -f "events/"
+  $ java -classpath `build-classpath-directory .` -Djavax.net.ssl.trustStore=/etc/candlepin/certs/amqp/candlepin.truststore -Djavax.net.ssl.keyStore=/etc/candlepin/certs/amqp/candlepin.jks -Djavax.net.ssl.keyStorePassword=password -Djavax.net.ssl.trustStorePassword=password org.apache.qpid.example.Drain --broker=guest:guest@localhost:5671 --broker-option=ssl=true,ssl_cert_alias=amqp -f "event/"
   ```
 * Create an org and watch for incoming messages.
 
@@ -117,12 +122,53 @@ With SSL, the best I've found is to use the Java client example, which needs a f
   $ ./cpc create_owner orgA
   ```
 
-Alternatively, you can use `qpid-printevents` although it does not let you
+Another option is to use `qpid-printevents` although it does not let you
 confine the output to a specific exchange.
 
 ```console
 $ qpid-printevents --ssl-certificate foo.cert --ssl-key foo.key amqps://localhost:5671
 ```
+
+## List of useful Qpid cli commands
+
+If you have set up a standalone qpid server, the ssl certificate can be found in `server/bin/qpid/keys/candlepin.crt`, and the ssl key in `server/bin/qpid/keys/candlepin.key`.
+
+* Get message counts and general stats.
+
+  ```console
+  $ sudo qpid-stat --ssl-certificate=path/to/cert --ssl-key path/to/key -b amqps://localhost:5671 -q allmsg
+  ```
+
+* List the bindings (routes) for a queue.
+
+  ```console
+  $ sudo qpid-config --ssl-certificate=path/to/cert --ssl-key path/to/key -b amqps://localhost:5671 queues allmsg -r
+  ```
+
+* List the current exchanges.
+
+  ```console
+  $ sudo qpid-config --ssl-certificate=path/to/cert --ssl-key path/to/key -b amqps://localhost:5671 exchanges
+  ```
+
+* Delete An Exchange.
+
+  ```console
+  $ sudo qpid-config --ssl-certificate=path/to/cert --ssl-key path/to/key -b amqps://localhost:5671 del exchange event
+  ```
+
+* Create an excange.
+
+  ```console
+  $ sudo qpid-config --ssl-certificate=path/to/cert --ssl-key path/to/key -b amqps://localhost:5671 add exchange topic event --durable
+  ```
+
+* Create a binding for the exchange.
+
+  ```console
+  $ sudo qpid-config --ssl-certificate=path/to/cert --ssl-key path/to/key -b amqps://localhost:5671 bind event allmsg '#'
+  ```
+
 
 # Configure SSL
 If you are running Pulp/Qpid on the same machine as your Candlepin server, you


### PR DESCRIPTION
- Add information about our own qpid client tool.
- Add a useful list of qpid commands.
- Fix dead links to python/java drain example tools.