### PR TITLE
Update with new instructions for building site container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ _site/
 *.patch
 .sass-cache
 .jekyll-metadata
+.jekyll-cache
 
 # Travis deployment cache directory
 .dpl
@@ -12,5 +13,3 @@ _site/
 # generated directory for plantuml diagrams
 uml/
 
-# source-to-image directory for Openshift
-.s2i

--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -20,6 +20,9 @@ function rake_assets_precompile() {
 
 set -e
 
+echo "---> Running as ..."
+id
+
 echo "---> Checking PlantUML ..."
 plantuml -v
 
@@ -68,9 +71,6 @@ if [[ "$RAILS_ENV" == "production" || "$RACK_ENV" == "production" ]]; then
   rake_assets_precompile
 fi
 
-# Fix source directory permissions
-fix-permissions ./
-
 # Make the ./tmp folder world writeable as Rails or other frameworks might use
 # it to store temporary data (uploads/cache/sessions/etcd).
 # The ./db folder has to be writeable as well because when Rails complete the
@@ -80,4 +80,9 @@ set +e
 [[ -d ./db ]] && chgrp -R 0 ./db && chmod -R g+rw ./db
 set -e
 
+echo "---> Building site ..."
 bundle exec jekyll build
+
+# Fix source directory permissions
+echo "---> Fixing directory permissions ..."
+fix-permissions ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,25 @@
-FROM centos/ruby-23-centos7
+FROM centos/ruby-27-centos7
 
-LABEL name="candlepin/website-ruby-23" \
+LABEL name="candlepin/website-ruby-27" \
       maintainer="Alex Wood <awood@redhat.com>"
 
 USER root
 
-RUN yum install -y --setopt=tsflags=nodocs java-1.6.0-openjdk-devel graphviz && \
+RUN yum install -y --setopt=tsflags=nodocs java-1.8.0-openjdk-devel graphviz python3 && \
     yum clean all -y
+
+# Keep this value up to date with the BUNDLED WITH version in Gemfile.lock
+RUN gem install bundler:2.2.15
 
 COPY ./.s2i/lib/plantuml.jar /usr/share/java/plantuml.jar
 COPY ./.s2i/lib/plantuml /usr/bin/plantuml
 RUN chmod 755 /usr/bin/plantuml
 
 COPY ./.s2i/bin/ $STI_SCRIPTS_PATH
+
+# Drop the root user and make the content of /opt/app-root owned by user 1001
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
+    rpm-file-permissions
 
 USER 1001
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     unicode-display_width (1.7.0)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Docker doesn't really work on Fedora anymore and isn't provided with
RHEL 8.  The instructions now use podman.  Unfortunately s2i doesn't
work natively with podman, so we have to build an intermediate
Dockerfile now instead of letting s2i build the final container.

Also added some new dependencies like an updated version of Bundler and
python3 which pygments requires.