### PR TITLE
Remove Nokogiri. Update container image name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/ruby-27-centos7
+FROM centos7/ruby-27-centos7
 
 LABEL name="candlepin/website-ruby-27" \
       maintainer="Alex Wood <awood@redhat.com>"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'jekyll-sitemap'
 gem 'kramdown', ">= 2.3.0"
 gem 'kramdown-parser-gfm'
 gem 'rack-jekyll', :git => 'https://github.com/awood/rack-jekyll'
-gem 'nokogiri'
 gem 'pygments.rb'
 gem 'stringex'
 gem 'rack', "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,20 +58,13 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    mini_portile2 (2.8.0)
     nio4r (2.5.8)
-    nokogiri (1.13.2)
-      mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
-    nokogiri (1.13.2-x86_64-linux)
-      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
     puma (5.5.1)
       nio4r (~> 2.0)
     pygments.rb (2.2.0)
-    racc (1.6.0)
     rack (2.2.3)
     rack-rewrite (1.5.1)
     rb-fsevent (0.10.4)
@@ -103,7 +96,6 @@ DEPENDENCIES
   jekyll-sitemap
   kramdown (>= 2.3.0)
   kramdown-parser-gfm
-  nokogiri
   puma
   pygments.rb
   rack (~> 2.2)
@@ -113,4 +105,4 @@ DEPENDENCIES
   typogruby
 
 BUNDLED WITH
-   2.2.15
+   2.3.10


### PR DESCRIPTION
We haven't actually used Nokogiri for ages.  A long time ago, we used it
for a custom Jekyll plugin that rendered the JSON definition of our API.
That plugin was removed a long time ago, but this dependency wasn't.

The container image for Centos' Ruby 2.7 container had a name change.