### PR TITLE
Update s2i assemble script to remove deprecated Bundler flags

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -38,9 +38,9 @@ mv /tmp/src/* ./
 
 echo "---> Building your Ruby application from source ..."
 if [ -f Gemfile ]; then
-  ADDTL_BUNDLE_ARGS=""
   if [ -f Gemfile.lock ]; then
-    ADDTL_BUNDLE_ARGS="--deployment"
+    echo "---> Setting Bundle deployment to true ..."
+    bundle config set --local deployment 'true'
   fi
 
   if [[ "$RAILS_ENV" == "development" || "$RACK_ENV" == "development" ]]; then
@@ -52,11 +52,13 @@ if [ -f Gemfile ]; then
   fi
 
   if [ -n "$BUNDLE_WITHOUT" ]; then
-    ADDTL_BUNDLE_ARGS+=" --without $BUNDLE_WITHOUT"
+    echo "---> Setting Bundle without to $BUNDLE_WITHOUT ..."
+    bundle config set --local without "$BUNDLE_WITHOUT"
   fi
 
-  echo "---> Running 'bundle install ${ADDTL_BUNDLE_ARGS}' ..."
-  bundle install --path ./bundle ${ADDTL_BUNDLE_ARGS}
+  echo "---> Running 'bundle install' ..."
+  bundle config set --local path './bundle'
+  bundle install
 
   echo "---> Cleaning up unused ruby gems ..."
   bundle clean -V

--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ If your changes work, you'll need to propagate them.
   `podman push --creds your:creds --format=docker docker.io/candlepin/website-ruby-27:latest`
 
 Openshift should be configured to watch that image repository and rebuild
-everything when it detects a change to the image.
+everything when it detects a change to the image.  If it does not, you can run
+`oc tag docker.io/candlepin/website-ruby-27:latest website-ruby-27:latest
+--scheduled=true`
 
 If you are starting with a brand new project or a brand new container tag,
 you'll need to import the image initially using `oc import-image


### PR DESCRIPTION
I was seeing the following warnings in the build logs:

[DEPRECATED] The `--deployment` flag is deprecated because it relies on
being remembered across bundler invocations, which bundler will no
longer do in future versions. Instead please use `bundle config set
--local deployment 'true'`, and stop using this flag

[DEPRECATED] The `--path` flag is deprecated because it relies on being
remembered across bundler invocations, which bundler will no longer do
in future versions. Instead please use `bundle config set --local path
'./bundle'`, and stop using this flag

[DEPRECATED] The `--without` flag is deprecated because it relies on
being remembered across bundler invocations, which bundler will no
longer do in future versions. Instead please use `bundle config set
--local without 'development:jekyll_plugins'`, and stop using this flag