### PR TITLE
The s2i assemble script is 644 instead of 755 in newer versions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -23,4 +23,4 @@ jobs:
         docker run \
         -v ${{ github.workspace }}:/tmp/src \
         candlepin/website-ruby-27:latest \
-        /bin/bash -c "chmod -R 777 /tmp/src && /usr/libexec/s2i/assemble"
+        /bin/bash -c "chmod -R 777 /tmp/src && bash /usr/libexec/s2i/assemble"


### PR DESCRIPTION
They changed the permissions on the s2i scripts and they're no longer
marked as executable.  Invoke them via bash now.  This has the nice
property of being backwards compatible.